### PR TITLE
Syncing for repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
     "convert": "for i in content/**/*.rst ; do python3 scripts/pre_pandoc_script.py ${i%}; echo \"$i\" && pandoc --wrap=none $i -f rst -t gfm -o ${i%.*}.mdx ; done ; python3 scripts/post_pandoc_script.py",
     "update-icons": "git submodule update --init --remote && node scripts/createIconTypes.js && node scripts/createIconNames.js",
-    "sync": "python3 scripts/sync_folders.py"
+    "sync": "python3 scripts/sync_repos.py"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
     "convert": "for i in content/**/*.rst ; do python3 scripts/pre_pandoc_script.py ${i%}; echo \"$i\" && pandoc --wrap=none $i -f rst -t gfm -o ${i%.*}.mdx ; done ; python3 scripts/post_pandoc_script.py",
-    "update-icons": "git submodule update --init --remote && node scripts/createIconTypes.js && node scripts/createIconNames.js"
+    "update-icons": "git submodule update --init --remote && node scripts/createIconTypes.js && node scripts/createIconNames.js",
+    "sync": "python3 scripts/sync_folders.py"
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.6.1",

--- a/scripts/sync_repos.py
+++ b/scripts/sync_repos.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import os
+import shutil
+
+# copy index over
+
+directory = os.getcwd()
+
+p = Path(directory)
+root = str(p.parents[0])
+
+shutil.move(directory + '/src/constants/index-link-list.js', directory)
+os.remove(root + '/edb-docs/src/components/katacoda.js')
+shutil.move(directory + '/src/components/katacoda.js',
+            root + '/edb-docs/src/components')
+shutil.rmtree(directory + '/src')
+shutil.copytree(root + '/edb-docs/src', directory + '/src')
+os.remove(directory + '/src/constants/index-link-list.js')
+shutil.move(directory + '/index-link-list.js', directory + '/src/constants')


### PR DESCRIPTION
Run `yarn sync` to sync repos. Both repo folders must be in the same parent folder.