### PR TITLE
basic issue templates for problems & requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem-with-topic.md
+++ b/.github/ISSUE_TEMPLATE/problem-with-topic.md
@@ -1,0 +1,27 @@
+---
+name: Problem with a topic
+about: Report a problem you've observed while reading a topic
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+A short description of the problem you observed. Ex: "Code sample fails with error", "Link is broken"
+
+## Where did you see the problem?
+
+Describe the location within the text, ex: "in the section titled 'Further reading', the 2nd link doesn't load"
+
+## Expected behavior
+Describe what you expected, changes you'd like to see, etc.
+
+## Screenshots
+If applicable, paste / upload screenshots to illustrate the problem you saw
+
+## Browser / Platform
+Include the name of the browser and operating system you were using, along with versions
+
+## Additional notes
+Anything else you'd like to add that might help us to fix the problem

--- a/.github/ISSUE_TEMPLATE/propose-new-topic.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-topic.md
@@ -1,0 +1,20 @@
+---
+name: Propose a new topic
+about: Suggest the addition of a new page or section
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+A short description of what you'd like to see covered
+
+## Background info
+
+What do you already know about the topic? What would you like to learn? What sort of things will this information help you to do?
+
+(If you're proposing this topic because you think it would benefit *someone else*, then summarize *their* background knowledge and needs)
+
+## Additional notes
+Anything else you'd like to add that might help us to fix the problem


### PR DESCRIPTION
Instead of putting these in contribute, include them in the GH UI. 

TODO: link to these *from* contribute