### PR TITLE
Link to issue report templates w/ page path prefilled in title on topic pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -187,12 +187,17 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       'https://github.com/rocketinsights/edb_docs_advocacy/edit/master/advocacy_docs' +
       doc.fields.path +
       (doc.fileAbsolutePath.includes('index.mdx') ? '/index.mdx' : '.mdx');
+    const githubIssuesLink = 
+      'https://github.com/rocketinsights/edb_docs_advocacy/issues/new?title=Regarding%20' +
+      doc.fields.path +
+      (doc.fileAbsolutePath.includes('index.mdx') ? '/index.mdx' : '.mdx');
     actions.createPage({
       path: doc.fields.path,
       component: require.resolve('./src/templates/learn-doc.js'),
       context: {
         navLinks: navLinks,
         githubLink: githubLink,
+        githubIssuesLink: githubIssuesLink,
       },
     });
   });

--- a/src/templates/learn-doc.js
+++ b/src/templates/learn-doc.js
@@ -67,7 +67,7 @@ const Tiles = ({ mdx, navLinks }) => {
 
 const LearnDocTemplate = ({ data, pageContext }) => {
   const { mdx } = data;
-  const { navLinks, githubLink } = pageContext;
+  const { navLinks, githubLink, githubIssuesLink } = pageContext;
   const pageMeta = {
     title: mdx.frontmatter.title,
     description: mdx.frontmatter.description,
@@ -112,6 +112,8 @@ const LearnDocTemplate = ({ data, pageContext }) => {
           )}
 
           <DevFrontmatter frontmatter={mdx.frontmatter} />
+
+          <p>Know of a way this page could be better? <a href={githubIssuesLink + "&template=problem-with-topic.md&labels=bug"}>Report a problem</a> or <a href={githubIssuesLink + "&template=suggest-addition-to-topic.md&labels=enhancement"}>suggest an addition</a>!</p>
 
           <Footer />
         </MainContent>


### PR DESCRIPTION
The goal here is to make it simple for folks to report issues (or suggest changes) on specific pages by providing links to issue templates at the bottom of the page:

![Know of a way this page could be better? Report a problem or suggest an addition!](https://user-images.githubusercontent.com/63653723/90455466-5fd84c00-e0b3-11ea-907e-da1260134846.png)

Those two links contain the path (not URL) of the page being viewed prepopulated as the title, along with references to the [specific template](https://github.com/rocketinsights/edb_docs_advocacy/tree/master/.github/ISSUE_TEMPLATE) with which to pre-fill the body of the report.

@epbarger I'd like your input on the approach here - I'm pretty much just copying the logic for the "Edit this page" button, but there may be a better way of including this (relatively simple) logic.

@cero-miedo any opinions on the (currently extremely sparse) design?