### PR TITLE
Katacoda panel component cleanup: hooks, CSS styling, bug fixes

### DIFF
--- a/src/advocacy_components/katacoda.js
+++ b/src/advocacy_components/katacoda.js
@@ -86,7 +86,7 @@ const Katacoda = ({
         if (panel && isShown)
         {
             // make room for the panel!
-            document.body.style.marginBottom =  "40%";
+            document.documentElement.classList.add("katacoda-panel-active");
             // detect when katacoda is closed via the internal button
             const handler = (e) => {
                 if (e.data.type === "close-panel" && e.data.data && e.data.data.target
@@ -97,7 +97,7 @@ const Katacoda = ({
             };
             window.addEventListener("message", handler);
             return () => {
-                document.body.style.marginBottom = ''
+                document.documentElement.classList.remove("katacoda-panel-active");
                 window.removeEventListener("message", handler);
             };
         }
@@ -108,12 +108,12 @@ const Katacoda = ({
             <script src="https://katacoda.com/embed.js" />
         </Helmet>
         <button type="button" onClick={toggleKata} className="btn btn-secondary">{isShown ? 'Close live demo' :  clickToShowText}</button>
-        <div className={`alert alert-info col-auto ${isShown && panel ? '' : 'd-none'}`} role="alert">(Click code blocks to execute in terminal)</div>
+        <div className={`alert alert-info col-auto${isShown && panel ? '' : ' d-none'}`} role="alert">(Click code blocks to execute in terminal)</div>
         <div id={panelElementId}
                 data-katacoda-id={scenarioId}
                 {...kataArgs}
                 style={{height: height}}
-                className={[className, isShown ? '' : 'd-none'].join(' ')}></div>
+                className={`${className}${isShown ? '' : ' d-none'}`}></div>
     </>
 };
 
@@ -135,12 +135,12 @@ function CodeTriggersKatacoda(codeSelector, isShown)
         const codeBlocks = document.querySelectorAll(codeSelector);
         window.addEventListener("click", callback);
         for (const c of codeBlocks) {
-            if (c.style.cursor === "pointer") continue;
-            c.style.cursor = "pointer";
+            if (c.classList.contains("katacoda-exec")) continue;
+            c.classList.add("katacoda-exec");
         }
         return () => {
             for (const c of codeBlocks)
-                c.style.cursor = "";        
+                c.classList.remove("katacoda-exec");
             window.removeEventListener("click", callback);
         };
     });

--- a/src/advocacy_components/katacoda.js
+++ b/src/advocacy_components/katacoda.js
@@ -1,135 +1,168 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 import { Helmet } from 'react-helmet';
 
-const Katacoda = ({account, 
-        scenario, 
-        clickToShowText = '',
-        panel = false,
-        layout = undefined, 
-        port = undefined, 
-        lang = undefined, 
-        token = undefined, 
-        userid = undefined, 
-        filename = undefined, 
-        command = undefined, 
-        runinbackground = undefined, 
-        prompt = undefined, 
-        color = "e94621", 
-        secondary = undefined, 
-        background = undefined, 
-        hideintro = undefined, 
-        hidefinish = undefined, 
-        hidetitle = undefined, 
-        hidesidebar = undefined, 
-        hideprogress = undefined, 
-        font = undefined, 
-        fontheader = undefined, 
-        startscenariobuttontext = undefined, 
-        ctaurl = undefined, 
-        ctatext = undefined, 
-        externalcss = undefined, 
-        hideiframebuttons = undefined,
-        height='600px', 
-        className='katacoda-embed',
-        codelanguages='shell'}) => {
+const Katacoda = ({
+    account, 
+    scenario, 
+    clickToShowText = '',
+    panel = false,
+    layout = undefined, 
+    port = undefined, 
+    lang = undefined, 
+    token = undefined, 
+    userid = undefined, 
+    filename = undefined, 
+    command = undefined, 
+    runinbackground = undefined, 
+    prompt = undefined, 
+    color = "e94621", 
+    secondary = undefined, 
+    background = undefined, 
+    hideintro = undefined, 
+    hidefinish = undefined, 
+    hidetitle = undefined, 
+    hidesidebar = undefined, 
+    hideprogress = undefined, 
+    font = undefined, 
+    fontheader = undefined, 
+    startscenariobuttontext = undefined, 
+    ctaurl = undefined, 
+    ctatext = undefined, 
+    externalcss = undefined, 
+    hideiframebuttons = undefined,
+    height='600px', 
+    className='katacoda-embed',
+    codelanguages='shell'}) => {
 
-        const kataArgs = 
+    const kataArgs = 
+    {
+        "data-katacoda-ui": panel ? 'panel' : undefined,
+        "data-katacoda-ondemand": panel && clickToShowText ? 'true' : undefined,
+        "data-katacoda-layout": layout,
+        "data-katacoda-port": port, 
+        "data-katacoda-lang": lang, 
+        "data-katacoda-token": token, 
+        "data-katacoda-userid": userid, 
+        "data-katacoda-filename": filename, 
+        "data-katacoda-command": command, 
+        "data-katacoda-runinbackground": runinbackground, 
+        "data-katacoda-prompt": prompt, 
+        "data-katacoda-color": color, 
+        "data-katacoda-secondary": secondary, 
+        "data-katacoda-background": background, 
+        "data-katacoda-hideintro": hideintro, 
+        "data-katacoda-hidefinish": hidefinish, 
+        "data-katacoda-hidetitle": hidetitle, 
+        "data-katacoda-hidesidebar": hidesidebar, 
+        "data-katacoda-hideprogress": hideprogress, 
+        "data-katacoda-font": font, 
+        "data-katacoda-fontheader": fontheader, 
+        "data-katacoda-startscenariobuttontext": startscenariobuttontext, 
+        "data-katacoda-ctaurl": ctaurl, 
+        "data-katacoda-ctatext": ctatext, 
+        "data-katacoda-externalcss": externalcss, 
+        "data-katacoda-hideiframebuttons": hideiframebuttons
+    };
+
+    const [isShown, setShown] = useState(!clickToShowText);
+    const scenarioId = account ? [account, scenario].join('/') : scenario;
+    const panelElementId = `katacoda-scenario-${account}-${scenario}`;
+    const codeBlocksSelector = codelanguages.split(",").map(l => "pre.language-" + l).join(",");
+
+    // no space reserved when using bottom panel
+    if ( panel ) height = '0';
+
+    const toggleKata = () => {
+        setShown(!isShown);
+        if (panel && !isShown) {
+            window.katacoda.init();
+            window.katacoda.write = KatacodaHttpsWrite;
+        }
+    };
+
+    CodeTriggersKatacoda(codeBlocksSelector, panel && isShown);
+
+    useLayoutEffect(() => {
+        if (panel && isShown)
         {
-            "data-katacoda-ui": panel ? 'panel' : undefined,
-            "data-katacoda-ondemand": panel && clickToShowText ? 'true' : undefined,
-            "data-katacoda-layout": layout,
-            "data-katacoda-port": port, 
-            "data-katacoda-lang": lang, 
-            "data-katacoda-token": token, 
-            "data-katacoda-userid": userid, 
-            "data-katacoda-filename": filename, 
-            "data-katacoda-command": command, 
-            "data-katacoda-runinbackground": runinbackground, 
-            "data-katacoda-prompt": prompt, 
-            "data-katacoda-color": color, 
-            "data-katacoda-secondary": secondary, 
-            "data-katacoda-background": background, 
-            "data-katacoda-hideintro": hideintro, 
-            "data-katacoda-hidefinish": hidefinish, 
-            "data-katacoda-hidetitle": hidetitle, 
-            "data-katacoda-hidesidebar": hidesidebar, 
-            "data-katacoda-hideprogress": hideprogress, 
-            "data-katacoda-font": font, 
-            "data-katacoda-fontheader": fontheader, 
-            "data-katacoda-startscenariobuttontext": startscenariobuttontext, 
-            "data-katacoda-ctaurl": ctaurl, 
-            "data-katacoda-ctatext": ctatext, 
-            "data-katacoda-externalcss": externalcss, 
-            "data-katacoda-hideiframebuttons": hideiframebuttons
-        };
-
-        const [shownClass, setShownClass] = useState(clickToShowText ? 'd-none' : '');
-        const scenarioId = account ? [account, scenario].join('/') : scenario;
-
-        // no space reserved when using bottom panel
-        if ( panel ) height = '0';
-
-        const toggleKata = () => {
-            if ( panel && shownClass )
-            {
-
-                // fixes two issues with Katacoda: 
-                // 1. KC likes to wire up <code> instead of <pre>, which plays hell with syntax highlighting
-                // 2. KC doesn't like to wire up anything that doesn't have its favorite attributes, 
-                //    which just makes using data awkward
-
-                WireCodeToKatacoda(codelanguages.split(",").map(l => "pre.language-" + l).join(","));
-
-                function WireCodeToKatacoda(selector) {
-                    var codeBlocks = document.querySelectorAll(selector);
-                    for (const c of codeBlocks) {
-                        if (c.style.cursor === "pointer") continue;
-                        c.style.cursor = "pointer";
-                        c.addEventListener("click", 
-                            (e) => window.katacoda.write(e.target.closest(selector).textContent), false);
-                    }
-                }
-
-                // adapted from Katacoda src to patch over http->https redirect issues
-                // when testing locally - remove once Katacoda has this fixed
-                window.katacoda.write = window.katacoda.writeToTerminal = function (cmd) {
-                    var target = document.querySelectorAll("[data-katacoda-env]");
-                    if (target.length === 0)
-                        target = document.querySelectorAll("[data-katacoda-id]");
-                    if (target.length === 0) {
-                        if (console && console.error) console.error("No katacoda elements found");
-                        return;
-                    }
-                    var p = document.getElementById(target[0].getAttribute("id"));
-                    var iframe = p.getElementsByTagName("iframe")[0];
-                    if (!iframe) return;
-                    var host = (new URL(iframe.src)).host;
-                    iframe.contentWindow.postMessage(
-                        { cmd: "writeTerm", data: cmd },
-                        "https://" + host
-                    );
-                };
-
-                // last hack: make room for the panel! This... Really needs a better idea.
-                document.querySelector("main").style.marginBottom="40%";
-
-                window.katacoda.init();
-            }
-            setShownClass(shownClass ? '' : 'd-none');
-        };
+            // make room for the panel!
+            document.body.style.marginBottom =  "40%";
+            // detect when katacoda is closed via the internal button
+            const handler = (e) => {
+                if (e.data.type === "close-panel" && e.data.data && e.data.data.target
+                    && e.data.data.target === panelElementId )
+                {
+                    setShown(false);
+                } 
+            };
+            window.addEventListener("message", handler);
+            return () => {
+                document.body.style.marginBottom = ''
+                window.removeEventListener("message", handler);
+            };
+        }
+    }, [panel, isShown, panelElementId, setShown]);
 
     return <>
         <Helmet>
             <script src="https://katacoda.com/embed.js" />
         </Helmet>
-        <button type="button" onClick={toggleKata} className="btn btn-secondary">{shownClass ? clickToShowText : 'Close live demo'}</button>
-        <div className={`alert alert-info col-auto ${shownClass}`} role="alert">(Click code blocks to execute in terminal)</div>
-        <div id={`katacoda-scenario-${account}-${scenario}`}
+        <button type="button" onClick={toggleKata} className="btn btn-secondary">{isShown ? 'Close live demo' :  clickToShowText}</button>
+        <div className={`alert alert-info col-auto ${isShown && panel ? '' : 'd-none'}`} role="alert">(Click code blocks to execute in terminal)</div>
+        <div id={panelElementId}
                 data-katacoda-id={scenarioId}
                 {...kataArgs}
                 style={{height: height}}
-                className={[className, shownClass].join(' ')}></div>
+                className={[className, isShown ? '' : 'd-none'].join(' ')}></div>
     </>
 };
-  
+
+// fixes two issues with Katacoda: 
+// 1. KC likes to wire up <code> instead of <pre>, which plays hell with syntax highlighting
+// 2. KC doesn't like to wire up anything that doesn't have its favorite attributes, 
+//    which just makes using data awkward
+function CodeTriggersKatacoda(codeSelector, isShown)
+{
+    useEffect(() => {
+        if (!isShown) return;
+
+        const callback = (e) =>
+        {
+            const matched = e.target.closest(codeSelector);
+            if (matched) window.katacoda.write(matched.textContent);
+        };
+    
+        const codeBlocks = document.querySelectorAll(codeSelector);
+        window.addEventListener("click", callback);
+        for (const c of codeBlocks) {
+            if (c.style.cursor === "pointer") continue;
+            c.style.cursor = "pointer";
+        }
+        return () => {
+            for (const c of codeBlocks)
+                c.style.cursor = "";        
+            window.removeEventListener("click", callback);
+        };
+    });
+}
+
+// adapted from Katacoda src to patch over http to https redirect issues
+// when testing locally - remove once Katacoda has this fixed
+function KatacodaHttpsWrite(cmd) {
+    var target = document.querySelectorAll("[data-katacoda-env]");
+    if (target.length === 0)
+        target = document.querySelectorAll("[data-katacoda-id]");
+    if (target.length === 0) {
+        if (console && console.error) console.error("No katacoda elements found");
+        return;
+    }
+    var p = document.getElementById(target[0].getAttribute("id"));
+    var iframe = p.getElementsByTagName("iframe")[0];
+    if (!iframe) return;
+    var host = (new URL(iframe.src)).host;
+    iframe.contentWindow.postMessage(
+        { cmd: "writeTerm", data: cmd },
+        "https://" + host
+    );                
+}
 export default Katacoda;

--- a/src/styles/_docs.scss
+++ b/src/styles/_docs.scss
@@ -40,6 +40,26 @@ main {
   box-shadow: 0px 0px 1px 1px $gray-100;
 }
 
+// Katacoda in panel display mode adds a fixed-position console with this height
+.katacoda-panel-active body
+{
+  margin-bottom: 40vh;
+}
+
+// Katacoda-enabled code blocks will have this class in panel display mode
+pre.katacoda-exec
+{
+  cursor: pointer;
+}
+
+// Because it is fixed position, the Katacoda panel screws up printing big-time
+@media print {
+  .katacoda-panel-active {
+    body { margin-bottom: unset; }
+    .katacoda-embed { display: none; }
+  }
+}
+
 .font-weight-400 {
   font-weight: 400;
 }


### PR DESCRIPTION
Katacoda does not, by default, play well with the React model - that leads to things like #77, where in-page navigation resets styles and event-handlers that Katacoda has applied to other elements on the page.

But with judicious application of Effect / LayoutEffect hooks, it's possible to mitigate this by ensuring that DOM modifications happen within React's lifecycle. Hence this PR:

- events are attached / detached and CSS classname applied / removed to `pre` elements matching the languages specified by the `codelanguages` property as the Katacoda panel is shown / hidden. This fixes #77. New CSS class, `katacoda-exec` is used to apply pointer styling; we may wish to use this to apply a more visible indication of interactivity in the future. cc @cero-miedo 
- New CSS class `katacoda-panel-active` is applied to the root element, allowing body margin to be increased when the panel is shown. Stylesheet includes a rule to match the height used by Katacoda (previously, some portion of body text was obscured when panel was active).
- Print styles to hide the panel (not that printed output is great otherwise, but visible panel on every page made it worse).
- Activation of the panel's close button is detected and triggers component reset (previously would result in the rest of the page behaving as though the panel was still visible)
- Show "click code blocks" alert only when in panel mode (was shown for embeds as well, where it makes no sense). 

TODO: merge stylesheet changes into edb_docs repo.