### PR TITLE
Trigger docs deploys on pushes to master

### DIFF
--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -1,0 +1,15 @@
+name: Trigger Deploy of Docs on Push
+on:
+  push:
+    branches:
+      - eb-trigger-deploy
+jobs:
+  trigger-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger docs develop deploy
+        run: |
+          curl -X POST https://api.github.com/repos/rocketinsights/edb_docs/dispatches \
+          -H 'Accept: application/json'
+          -u ${{ secrets.GH_DOCS_ACCESS_TOKEN }}
+          --data '{"event_type": "advo-deploy", "client_payload": {"branch": "develop", repository": "'"$GITHUB_REPOSITORY"'"}}'

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -7,9 +7,9 @@ jobs:
   trigger-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: trigger docs develop deploy
-        run: |
-          curl -X POST https://api.github.com/repos/rocketinsights/edb_docs/dispatches \
-          -H 'Accept: application/vnd.github.v3+json' \
-          -u ${{ secrets.GH_DOCS_ACCESS_TOKEN }} \
-          --data '{"event_type": "advo-deploy", "client_payload": {"branch": "develop"}}'
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GH_DOCS_ACCESS_TOKEN }}
+          repository: rocketinsights/edb_docs
+          event-type: advo-deploy-develop

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -10,6 +10,6 @@ jobs:
       - name: trigger docs develop deploy
         run: |
           curl -X POST https://api.github.com/repos/rocketinsights/edb_docs/dispatches \
-          -H 'Accept: application/json'
-          -u ${{ secrets.GH_DOCS_ACCESS_TOKEN }}
-          --data '{"event_type": "advo-deploy", "client_payload": {"branch": "develop", repository": "'"$GITHUB_REPOSITORY"'"}}'
+          -H 'Accept: application/vnd.github.v3+json' \
+          -u ${{ secrets.GH_DOCS_ACCESS_TOKEN }} \
+          --data '{"event_type": "advo-deploy", "client_payload": {"branch": "develop"}}'

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -7,9 +7,15 @@ jobs:
   trigger-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Repository Dispatch
+      - name: Repository Dispatch to Docs Staging
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.GH_DOCS_ACCESS_TOKEN }}
           repository: rocketinsights/edb_docs
           event-type: advo-deploy-develop
+      - name: Repository Dispatch to Docs Production
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GH_DOCS_ACCESS_TOKEN }}
+          repository: rocketinsights/edb_docs
+          event-type: advo-deploy-prod

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -2,7 +2,7 @@ name: Trigger Deploy of Docs on Push
 on:
   push:
     branches:
-      - eb-trigger-deploy
+      - master
 jobs:
   trigger-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See title. Uses a GH workflow to send events to the docs repo when code gets merged into master