### PR TITLE
update Katacoda usage and docs to match Evan's new components

### DIFF
--- a/advocacy_docs/building/sql/views.mdx
+++ b/advocacy_docs/building/sql/views.mdx
@@ -10,7 +10,6 @@ tags:
     - psql
     - live-demo
 ---
-import Katacoda from '../../../src/advocacy_components/katacoda';
 
 *adapted from: https://www.enterprisedb.com/postgres-tutorials/how-create-modify-delete-and-manage-views-postgresql*
 
@@ -18,12 +17,9 @@ import Katacoda from '../../../src/advocacy_components/katacoda';
 
 PostgreSQL’s VIEW is a versatile tool for “viewing” the data in a database. A VIEW is a query that you give a name to so that you can reference it just like you would a table. There are also MATERIALIZED VIEWs, which are similar but slightly different, and we cover that here. A VIEW doesn’t replace a table—VIEWs require tables to pull information from them. However, once those tables are in place, you can use VIEWs to examine and use those tables’ data. This can be useful for a number of situations. For example, if there’s a query that you run really often, and you don’t want to keep typing it, you can use a VIEW. 
 
-This is an interactive tutorial - you can run the examples below against a sample database by launching Katacoda in your browser.
-<Katacoda 
- account="enterprisedb" scenario="sandbox" 
- clickToShowText="Launch Katacoda" 
- panel="true"
- codelanguages="sql"/>
+This is an interactive tutorial - you can run the examples below against a sample database right in your browser.
+
+<KatacodaPanel account="enterprisedb" scenario="sandbox" codelanguages="sql"/>
 
 ## Creating a view
 

--- a/advocacy_docs/community/contribute/planning/demo.mdx
+++ b/advocacy_docs/community/contribute/planning/demo.mdx
@@ -34,19 +34,30 @@ The crucial decision here will generally boil down to whether or not you need an
 
 3. Make sure code blocks are marked with the language represented in them (sql, shell, etc)
 
-4. Add a `<Katacoda>` element - this will render a button that will allow the reader to load Katacoda in the page:
+4. Add a `<KatacodaPanel>` element - this will render a button that will allow the reader to load Katacoda in the page:
 
-        import Katacoda from '../../../../src/advocacy_components/katacoda';
+   ```markdown
+   This is an interactive tutorial - you may launch a console
+   in your browser to run the examples below.
+   <KatacodaPanel account="enterprisedb" 
+      scenario="sandbox" 
+      codelanguages="sql"/>
+   ```
 
-        This is an interactive tutorial - click to run samples by launching the Katacoda console in your browser.
-        <Katacoda 
-        account="enterprisedb" scenario="sandbox" 
-        clickToShowText="Launch Katacoda" 
-        panel="true"
-        codelanguages="sql"/>
+   The scenario attribute defines the environment that will be used; `sandbox` is a custom PostgreSQL-on-Ubuntu image that Dave put together with the Pagila example database pre-installed, suitable for demonstrating SQL and some management. The property `codelanguages` specifies a comma-separated list of language names: code blocks highlighted in these languages will execute in the terminal when clicked. Specify the highlighting language for a code block next to the opening fence, e.g.
 
-   The scenario attribute defines the environment that will be used; `sandbox` is a custom PostgreSQL-on-Ubuntu image that Dave put together with the Pagila example database pre-installed, suitable for demonstrating SQL and some management.
+   ~~~
+   ```sql
+   Select * From films;
+   ```
+   ~~~
 
+   Note: in some cases, you won't need a scenario, just a base environment (for example, demonstrating installation on Ubuntu needs only an Ubuntu environment). In these cases, omit the `account` property and specify the name of the environment in the `scenario` property.
+
+   ```markdown
+   <KatacodaPanel scenario="ubuntu1804" />
+   ```
+   
 6. Drop your file (with an mdx extension) in the relevant section of this repository
 <!-- Demo only: add top level section for "building/sql" to illustrate that too -->
 
@@ -120,14 +131,27 @@ The crucial decision here will generally boil down to whether or not you need an
 
 7. Create article page (see [Format](../style) for details)
 
-   ```
-   import Katacoda from '../../../../src/advocacy_components/katacoda';
+   Add a `kataCodaPages` key in the Frontmatter at the top of the page. The value will be a list of Katacoda scenario names with an associated Katacoda account for each.
 
-   <Katacoda account="shog9" scenario="java-jdbc" 
-    hideintro="true" 
-    clickToShowText='Start tutorial' />
+   ```yaml
+   katacodaPages:
+    - scenario: install-ubuntu
+      account: enterprisedb
+    - scenario: java-jdbc
+      account: shog9
    ```
-   Include at least a short into / explanation for the tutorial
+
+   The scenario name will be used to refer to the scenario later in the page, *and* will be used in the path for the scenario page within the site; for this reason, avoid using the same scenario name across different accounts on the same page (this should never be necessary). 
+
+   Once you've defined the relevant scenarios, you'll link to them within the article text using the `KatacodaPageLink` element:
+
+   ```markdown
+   <KatacodaPageLink scenario="java-jdbc"/>
+   ```
+
+   Include at least a short into / explanation for the link. A good place to start is the description defined in the scenario itself. Ex:
+
+   > This tutorial demonstrates how to connect to an existing PostgreSQL database from Java using JDBC.
 
    Name the article with an .mdx extension and put it in the relevant section of this repository
 

--- a/advocacy_docs/community/contribute/style/index.mdx
+++ b/advocacy_docs/community/contribute/style/index.mdx
@@ -21,6 +21,9 @@ tags: list of relevant keywords (used for related articles) Ex.
     - ubuntu
     - psql
     - live-demo
+katacodaPages: (optional) list of Katacoda scenarios linked in the page
+    - scenario: install-ubuntu
+      account: enterprisedb
 ---
 
 ```
@@ -41,19 +44,22 @@ Get into the *actual* information.
 ### Subsection
 
 Break up long runs of text into subsections. 
-Level 3 headings (###) will *not* appear in the table of contents.
+Level 3 headings (###) will *not* appear 
+in the table of contents.
 
 ## Demo
 
 MDX allows including and referencing React components 
 as well, which is handy for things like Katacoda embeds:
 
-import Katacoda from '../../../../src/advocacy_components/katacoda';
-
-<Katacoda 
- account="enterprisedb" scenario="sandbox" 
- clickToShowText="Use psql on the Pagila database" 
- panel="true"/>
+<!-- button to launch a terminal panel at the bottom of the page 
+    and make SQL code blocks executable in it -->
+<KatacodaPanel account="enterprisedb" 
+    scenario="sandbox"
+    codeLanguages="sql" />
+<!-- this will create a link to the scenario described in 
+    the Frontmatter at the top of this article -->
+<KatacodaPageLink scenario="install-ubuntu" />
 ```
 
 ## Further reading

--- a/advocacy_docs/getting-started/connecting_to_postgres/java/01_hibernate.mdx
+++ b/advocacy_docs/getting-started/connecting_to_postgres/java/01_hibernate.mdx
@@ -10,7 +10,6 @@ tags:
     - hibernate
     - jpa
 ---
-import Katacoda from '../../../../src/advocacy_components/katacoda';
 
 Hibernate is a widely-used ORM framework which attempts to abstract away the tasks involved when storing and retrieving Java objects. It is configured via settings, which may be specified programmatically, via a configuration file, or provided via an IOC container (see also: [Spring Data](03_springdata.mdx)).
 

--- a/advocacy_docs/getting-started/connecting_to_postgres/java/02_JDBC.mdx
+++ b/advocacy_docs/getting-started/connecting_to_postgres/java/02_JDBC.mdx
@@ -61,17 +61,6 @@ If you're used to working with Oracle and wish to move to PostgreSQL while retai
 
 This tutorial demonstrates how to connect to an existing PostgreSQL database from Java using JDBC. It runs in your browser, and should take about 5 minutes to complete.
 
-### What you'll do in this tutorial
-
-1. Install the PostgreSQL JDBC driver
-2. Write a minimal amount of code to connect & run a query using that driver
-3. Run your code and observe the results
-
-### What's already done
-
-- A development environment with Java installed is ready 
-- A fresh PostgreSQL database named "demo" has been created, and is accessible via port 5432
-
 <KatacodaPageLink scenario="java-jdbc" />
 
 - - -

--- a/advocacy_docs/getting-started/connecting_to_postgres/java/03_springdata.mdx
+++ b/advocacy_docs/getting-started/connecting_to_postgres/java/03_springdata.mdx
@@ -11,7 +11,6 @@ tags:
     - spring-boot
     - spring-data
 ---
-import Katacoda from '../../../../src/advocacy_components/katacoda';
 
 The Spring Framework is a collection of libraries, tools and practices aimed at easing the amount of work that needs to be done to write and configure applications built from components. For details, see [Core Technologies](https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans) in the Spring documentation. 
 

--- a/advocacy_docs/getting-started/connecting_to_postgres/python/02_django.mdx
+++ b/advocacy_docs/getting-started/connecting_to_postgres/python/02_django.mdx
@@ -9,8 +9,10 @@ tags:
     - python
     - django
     - live-demo
+katacodaPages:
+    - scenario: django2
+      account: shog9
 ---
-import Katacoda from '../../../../src/advocacy_components/katacoda';
 
 Django allows persisting and querying data models via [a rich set of options to map classes to database tables](https://docs.djangoproject.com/en/3.0/topics/db/). The connection to PostgreSQL is configured via the "default" key in the `DATABASES` dictionary in Django settings (usually configured by editing a project's `settings.py`):
 
@@ -36,23 +38,7 @@ Refer to [the Django documentation](https://docs.djangoproject.com/en/3.0/topics
 
 This tutorial demonstrates how to use PostgreSQL together with the Python web application framework Django. It is an adaptation of Richard Yen's tutorial found at: https://www.enterprisedb.com/postgres-tutorials/how-use-postgresql-django
 
-### Expectations
-You have data that you need to display on the web. A PostgreSQL database is available to store the data. You have a basic familiarity with Python, basic Linux commands, and with SQL.
-
-### What you'll do in this tutorial
-
-1. Install Django and psycopg2
-2. Create a new Django app and connect it to PostgreSQL 
-3. Create data models and run a migration to set up the PostgreSQL tables
-4. Create views, set up URL routing
-5. Run the app!
-
-### What's already done
-
-- A development environment with Python installed is ready 
-- A fresh PostgreSQL database named "demo" has been created, and is accessible via port 5432
-
-<Katacoda account="shog9" scenario="django2" hideintro="true" clickToShowText='Start tutorial'/>
+<KatacodaPageLink scenario="django2" />
 
 ---
 

--- a/advocacy_docs/getting-started/installing_postgres/docker.mdx
+++ b/advocacy_docs/getting-started/installing_postgres/docker.mdx
@@ -12,7 +12,6 @@ tags:
     - ubuntu
 iconName: dockercolor
 ---
-import Katacoda from '../../../src/advocacy_components/katacoda';
 
 Docker containers are an environment which exist and run independently from whatever else is running on a given machine. Containers are created from "images", which define what a given environment will look like - file system layout, running processes, etc. This makes them very convenient for side-stepping the whole "installation" problem: an image in which the necessary software has already been installed and configured can be distributed and used to create containers on any machine with Docker available.
 
@@ -22,7 +21,7 @@ Let's start by spinning up a local PostgreSQL server using one of the images ava
 
 Make sure you have Docker installed. If not, install it using [the instructions on the Docker website](https://docs.docker.com/get-docker/).
 
-Alternately, you can follow these steps in your browser: <Katacoda scenario="ubuntu1804" clickToShowText="Live demo using Ubuntu" panel="true"/>
+Alternately, you can follow these steps in your browser: <KatacodaPanel scenario="ubuntu1804" />
 
 1. Retrieve the PostgreSQL image from the Docker Hub repository (if not already cached) and run it:
 

--- a/advocacy_docs/getting-started/installing_postgres/linux.mdx
+++ b/advocacy_docs/getting-started/installing_postgres/linux.mdx
@@ -11,7 +11,6 @@ tags:
     - live-demo
 iconName: linuxcolor
 ---
-import Katacoda from '../../../src/advocacy_components/katacoda';
 
 ## Basic installation
 
@@ -37,7 +36,7 @@ The platform-native installation packages will accomplish all of the above, alth
 
 This tutorial will walk through the steps for installing a PostgreSQL server on Ubuntu 18.04.4 LTS.
 
-<Katacoda scenario="ubuntu1804" clickToShowText="Live demo using Ubuntu" panel="true"/>
+<KatacodaPanel scenario="ubuntu1804" />
 
 First, we need to add the Postgresql.org repository as a source for Ubuntu's APT package manager:
 
@@ -47,7 +46,9 @@ sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)
 
 The command `lsb_release -cs` retrieves the name of the installed OS version, in this case "bionic" - this ensures that we're pulling from the correct repository for this release of the operating system. Supported releases can be found on [the PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt). The resulting [sources file](https://wiki.debian.org/SourcesList) looks like this:
 
-> deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
+```output
+deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
+```
 
 APT won't trust the new source until we provide it with [a trusted key](http://manpages.ubuntu.com/manpages/xenial/man8/apt-secure.8.html) - we can pull that from postgresql.org and add it with the apt-key utility:
 


### PR DESCRIPTION
Only doing a PR here to give me a place to make notes. Key changes:

- Document usage of `KatacodaPanel` and `KatacodaPageLink` + new Frontmatter list
  - two places for this: briefly in contrib->style and more extensively in contrib->planning->demo
- Update all panel usage to `KatacodaPanel` component
- Update all embeds to `KatacodaPageLink`+Frontmatter list
- Remove all instances where the intro section for the embed was duplicated in the article (this only made sense when it wasn't a separate page)
- Remove all imports (both Katacoda components are default available now)
